### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Type: `Object`
 `optional`
 
 The `dev` property should contain options for `webpack-hot-middleware`, a list of
-which is available at [webpack-hot-middleware](https://github.com/webpack/webpack-hot-middleware).
+which is available at [webpack-hot-middleware](https://github.com/glenjamin/webpack-hot-middleware).
 Omitting this property will result in `webpack-hot-middleware` using its default
 options.
 


### PR DESCRIPTION
The link for `webpack-hot-middleware` was broken.