### PR TITLE
Don't prematurely set hot middleware body/headers

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -124,19 +124,17 @@ function koaHotware(compiler, options) {
           switch (_context2.prev = _context2.next) {
             case 0:
               stream = new _stream.PassThrough();
-
-              context.body = stream;
-
-              _context2.next = 4;
+              _context2.next = 3;
               return hot(context.req, {
                 write: stream.write.bind(stream),
-                writeHead: function writeHead(state, headers) {
-                  context.state = state;
+                writeHead: function writeHead(status, headers) {
+                  context.body = stream;
+                  context.status = status;
                   context.set(headers);
                 }
               }, next);
 
-            case 4:
+            case 3:
             case 'end':
               return _context2.stop();
           }

--- a/index.js
+++ b/index.js
@@ -49,12 +49,12 @@ function koaHotware (compiler, options) {
 
   return async (context, next) => {
     let stream = new PassThrough();
-    context.body = stream;
 
     await hot(context.req, {
       write: stream.write.bind(stream),
-      writeHead: (state, headers) => {
-        context.state = state;
+      writeHead: (status, headers) => {
+        context.body = stream;
+        context.status = status;
         context.set(headers);
       }
     }, next);


### PR DESCRIPTION
Fixes #23 with minimal changes.

In the [original middleware](https://github.com/glenjamin/webpack-hot-middleware/blob/master/middleware.js) `writeHead` is the first method called on the response object, so I moved the body assignment into there. This way it only gets set after the path check succeeds.

I also took the opportunity to fix the erroneous `context.state` assignment (I'm sure people wouldn't appreciate that being overwritten).

Did a couple of manual tests and it seems to work fine.