### PR TITLE
Correct middleware export

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,21 +1,4 @@
 {
-  "parser": "babel-eslint",
-  "rules": {
-    "consistent-return": [0],
-    "complexity": [0],
-    "space-before-function-paren": [0],
-    "indent": [2, 2, { "SwitchCase": 1, "VariableDeclarator": 1 }],
-    "max-len": [1, 1000],
-    "brace-style": [2, "stroustrup", { "allowSingleLine": true }],
-    "space-unary-ops": [0],
-    "one-var": ["error", "always"],
-    "no-extra-parens": [0],
-    "no-bitwise": [0],
-    "semi": [2, "always"],
-    "prefer-arrow-callback": ["error", { "allowNamedFunctions": true }]
-  },
-  "env": {
-    "mocha": true,
-    "node": true
-  }
+  "extends": "shellscape",
+  "parser": "babel-eslint"
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # koa-webpack [![Build Status](https://travis-ci.org/shellscape/koa-webpack.svg?branch=master)](https://travis-ci.org/shellscape/koa-webpack)
 
-Development and Hot Module Reload Middleware for Koa2, in a single middleware module.
+Development and Hot Module Reload Middleware for **Koa2**, in a single middleware module.
 
 This module wraps and composes `webpack-dev-middleware` and `webpack-hot-middleware`
 into a single middleware module, allowing for quick and concise implementation.
@@ -37,6 +37,29 @@ const app = new Koa();
 app.use(middleware({
   // options
 }))
+```
+
+### Accessing the Underlying Middleware
+
+In some cases, you may have the need to access the `webpack-dev-middleware` or
+`webpack-hot-middleware` instances that this module composes. As of `v0.3.0` you
+can access both by using the following pattern:
+
+```js
+import Koa from 'koa';
+import koaWebpack from 'koa-webpack';
+
+const app = new Koa();
+const middleware = koaWebpack({
+  // options
+});
+
+app.use(middleware);
+
+function doSomething () {
+  middleware.hot.publish({ action: 'reload' })
+}
+
 ```
 
 ## Options

--- a/dist/index.js
+++ b/dist/index.js
@@ -20,6 +20,8 @@ var _promise = require('babel-runtime/core-js/promise');
 
 var _promise2 = _interopRequireDefault(_promise);
 
+exports.default = fn;
+
 var _webpack = require('webpack');
 
 var _webpack2 = _interopRequireDefault(_webpack);
@@ -54,10 +56,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  * @method koaDevware
  * @desc   Middleware for Koa to proxy webpack-dev-middleware
  **/
-function koaDevware(compiler, options) {
+function koaDevware(dev, compiler) {
   var _this = this;
-
-  var dev = (0, _webpackDevMiddleware2.default)(compiler, options);
 
   /**
    * @method waitMiddleware
@@ -111,10 +111,8 @@ function koaDevware(compiler, options) {
  * @method koaHotware
  * @desc   Middleware for Koa to proxy webpack-hot-middleware
  **/
-function koaHotware(compiler, options) {
+function koaHotware(hot, compiler) {
   var _this2 = this;
-
-  var hot = (0, _webpackHotMiddleware2.default)(compiler, options);
 
   return function () {
     var _ref2 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee2(context, next) {
@@ -178,8 +176,11 @@ function fn(options) {
     options.dev.publicPath = publicPath;
   }
 
-  return (0, _koaCompose2.default)([koaDevware(compiler, options.dev), koaHotware(compiler, options.hot)]);
-};
+  var dev = (0, _webpackDevMiddleware2.default)(compiler, options.dev);
+  var hot = (0, _webpackHotMiddleware2.default)(compiler, options.hot);
 
-exports.default = (0, _assign2.default)(fn, { devMiddleware: _webpackDevMiddleware2.default, hotMiddleware: _webpackHotMiddleware2.default });
+  var middleware = (0, _koaCompose2.default)([koaDevware(dev, compiler), koaHotware(hot, compiler)]);
+
+  return (0, _assign2.default)(middleware, { dev: dev, hot: hot });
+};
 module.exports = exports['default'];

--- a/index.js
+++ b/index.js
@@ -10,8 +10,7 @@ import * as path from 'path';
  * @method koaDevware
  * @desc   Middleware for Koa to proxy webpack-dev-middleware
  **/
-function koaDevware (compiler, options) {
-  const dev = devMiddleware(compiler, options);
+function koaDevware (dev, compiler) {
 
   /**
    * @method waitMiddleware
@@ -44,8 +43,7 @@ function koaDevware (compiler, options) {
  * @method koaHotware
  * @desc   Middleware for Koa to proxy webpack-hot-middleware
  **/
-function koaHotware (compiler, options) {
-  const hot = hotMiddleware(compiler, options);
+function koaHotware (hot, compiler) {
 
   return async (context, next) => {
     let stream = new PassThrough();
@@ -64,7 +62,7 @@ function koaHotware (compiler, options) {
 /**
  * The entry point for the Koa middleware.
  **/
-function fn (options) {
+export default function fn (options) {
 
   const defaults = { dev: {}, hot: {} };
 
@@ -91,10 +89,13 @@ function fn (options) {
     options.dev.publicPath = publicPath;
   }
 
-  return compose([
-    koaDevware(compiler, options.dev),
-    koaHotware(compiler, options.hot)
-  ]);
-};
+  const dev = devMiddleware(compiler, options.dev);
+  const hot = hotMiddleware(compiler, options.hot);
 
-export default Object.assign(fn, { devMiddleware, hotMiddleware });
+  const middleware = compose([
+    koaDevware(dev, compiler),
+    koaHotware(hot, compiler)
+  ]);
+
+  return Object.assign(middleware, { dev, hot });
+};

--- a/package.json
+++ b/package.json
@@ -19,11 +19,9 @@
   "dependencies": {
     "app-root-path": "^2.0.1",
     "koa-compose": "^3.1.0",
+    "webpack": "~2.2.0",
     "webpack-dev-middleware": "^1.8.4",
     "webpack-hot-middleware": "^2.13.0"
-  },
-  "peerDependencies": {
-    "webpack": "~2.2.0"
   },
   "devDependencies": {
     "babel": "^6.5.2",
@@ -36,6 +34,7 @@
     "babel-register": "^6.16.3",
     "del": "^2.2.2",
     "eslint": "^3.8.1",
+    "eslint-config-shellscape": "^1.0.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-eslint": "^3.0.1",


### PR DESCRIPTION
reverts the default export to a single function with no additional properties. the result of the exported function contains references to the underlying dev and hot middleware. implements the changes requested by @blade254353074 in #26 