### PR TITLE
Set locals field on the dev-middleware response argument 

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,8 @@ function koaDevware (dev, compiler) {
       end: (content) => {
         context.body = content;
       },
-      setHeader: context.set.bind(context)
+      setHeader: context.set.bind(context),
+      locals: context.state
     }, next);
   };
 }


### PR DESCRIPTION
Fixes #28.
Context.state seems to be the koa equivalent to res.locals in express.