### PR TITLE
fix async continuation when using lazy mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,13 +30,16 @@ function koaDevware (dev, compiler) {
 
   return async (context, next) => {
     await waitMiddleware();
-    await dev(context.req, {
-      end: (content) => {
-        context.body = content;
-      },
-      setHeader: context.set.bind(context),
-      locals: context.state
-    }, next);
+    await new Promise((resolve, reject) => {
+      dev(context.req, {
+        end: (content) => {
+          context.body = content;
+          resolve();
+        },
+        setHeader: context.set.bind(context),
+        locals: context.state
+      }, () => resolve(next()));
+    });
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Development and Hot Reload Middleware for Koa2",
   "main": "dist/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "eslint index.js test/*.js && mocha --compilers=js:babel-register"
   },
   "repository": {
     "type": "git",
@@ -32,12 +32,16 @@
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-stage-2": "^6.17.0",
     "babel-register": "^6.16.3",
+    "deepmerge": "^1.3.2",
     "del": "^2.2.2",
     "eslint": "^3.8.1",
     "eslint-config-shellscape": "^1.0.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-eslint": "^3.0.1",
+    "koa": "^2.2.0",
+    "mocha": "^3.3.0",
+    "supertest": "^3.0.0",
     "webpack": "^2.5.1"
   }
 }

--- a/test/fixtures/input.js
+++ b/test/fixtures/input.js
@@ -1,0 +1,1 @@
+console.log("Hello world");

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,81 @@
+import * as assert from 'assert';
+import * as path from 'path';
+
+import merge from 'deepmerge';
+import Koa from 'koa';
+import compose from 'koa-compose';
+import request from 'supertest';
+import Webpack from 'webpack';
+
+import koaWebpack from '../index';
+
+const DEFAULT_OPTIONS = {
+  config: {
+    entry: path.resolve(__dirname, 'fixtures', 'input.js'),
+    output: {
+      path: path.resolve(__dirname, 'fixtures'),
+      filename: 'output.js',
+    },
+  },
+  dev: {
+    publicPath: '/',
+    noInfo: true,
+    quiet: true,
+  },
+};
+
+function buildOptions (options) {
+  options = merge(DEFAULT_OPTIONS, options);
+  return merge(options, {
+    config: null,
+    compiler: Webpack(options.config),
+  });
+};
+
+function defaultApp (middleware) {
+  return middleware;
+}
+
+function requestWith (options, setupMiddleware = defaultApp) {
+  const app = new Koa();
+  const webpackMiddleware = koaWebpack(buildOptions(options));
+  app.use(setupMiddleware(webpackMiddleware));
+  const server = app.listen();
+  return request(server);
+};
+
+describe('devMiddleware', () => {
+  it('sends the result in watch mode', () => {
+    return requestWith({ dev: { lazy: false } })
+      .get('/output.js')
+      .expect(200)
+      .expect(response => {
+        assert.ok(/Hello world/.test(response.text),
+          "Expected result to contain 'Hello world'");
+      });
+  });
+
+  it('builds and sends the result in lazy mode', () => {
+    return requestWith({ dev: { lazy: true } })
+      .get('/output.js')
+      .expect(200)
+      .expect(response => {
+        assert.ok(/Hello world/.test(response.text),
+          "Expected result to contain 'Hello world'");
+      });
+  });
+
+  it('continues on if the file is not part of webpack', () => {
+    const middleware = (webpack) =>
+      compose([
+        webpack,
+        async (ctx) => {
+          ctx.body = 'foo';
+        },
+      ]);
+
+    return requestWith({}, middleware)
+      .get('/some-other-file.js')
+      .expect(200, 'foo');
+  });
+});


### PR DESCRIPTION
The middleware is an `async` arrow function that makes a call to the
underlying `webpack-dev-middleware` middleware, which acts as a
middleware to the express framework, so it does not work in terms of
promises. As such, it does not explicitly return anything, though it
does, under some branches, call `return next()`. Since the `next` we are
passing in our wrapper is a function that returns a promise, this works
some of the time. However, with the `lazy: true` option, it will do the
responding asynchronously, and thus it returns `undefined`. This means
the `await` in the wrapper will end synchronously, ending the middleware
and passing control back to koa, which will probably return a 404.
However, the `webpack-dev-middleware` may eventually compile the file
and then either try to set the headers and body to send the response or
call `next`, even though koa has already finished with it.

Depending on what other koa middleware is present, this will manifest as
a 404 to the end user, and either an unhandled promise exception or a
server crash. The solution is to create a promise to wrap the
middleware, and either resolve it when the body is written or resolve it
when the `next` is called.

This also adds a small set of tests for some very basic functionality
for lazy and non-lazy compilation.

---

Fixes #48. I don't know what you had in mind for tests, so I went for the things that I knew and could get the most traction as quickly as possible. I know there are certainly more things to test, but this is all I could do with my time. I hope that's not too far from what you want. Given that I don't understand the hot middleware at all, yet, I did not add any tests or make any code changes.