### PR TITLE
Fix node-v6 failed builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "app-root-path": "^2.0.1",
     "merge-options": "^1.0.0",
     "webpack-dev-middleware": "^2.0.3",
-    "webpack-hot-client": "^1.0.1",
+    "webpack-hot-client": "1.0.1",
     "webpack-log": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
node-v6 ships with npm v3 which doesn't have package-lock support.  The CI was
thus installing the latest minor version of webpack-hot-client which recently
removed babel-preset-env from its list of dependencies in a minor bump.

- pin webpack-hot-client@1.0.1