### PR TITLE
fix: `options.compiler` is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,16 @@ $ npm install koa-webpack --save-dev
 Next, setup the module in your code. (We're assuming ES6 syntax here)
 
 ```js
-const Koa = require('koa');
-const middleware = require('koa-webpack');
+import Koa from 'koa';
+import koaWebpack from 'koa-webpack';
 
 const app = new Koa();
 
-app.use(middleware({
+koaWebpack({
   // options
-}))
+}).then(middleware => {
+  app.use(middleware)
+})
 ```
 
 ## API
@@ -84,14 +86,16 @@ this option.
 Example:
 
 ```js
+import koaWebpack from 'koa-webpack'
 import Webpack from 'webpack';
 import config from './webpack.config.js';
 
 const compiler = Webpack(config);
 
-app.use(middleware({
-  compiler: compiler
-}))
+koaWebpack({ compiler })
+  .then(middleware => {
+    app.use(middleware)
+});
 ```
 
 ### config
@@ -106,12 +110,12 @@ this option.
 Example:
 
 ```js
-const config = require('./webpack.config.js');
-const koaWebpack = require('koa-webpack');
+import koaWebpack from 'koa-webpack'
+import config from './webpack.config.js';
 
 koaWebpack({ config })
- .then((middleware) => {
-  app.use(middleware);
+  .then(middleware => {
+    app.use(middleware)
 });
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,6 +72,7 @@ module.exports = (opts) => {
     }
 
     compiler = webpack(config);
+    options.compiler = compiler;
   }
 
   if (!options.devMiddleware.publicPath) {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

https://github.com/shellscape/koa-webpack/blob/master/lib/index.js#L30-L40

`options.compiler` is used after initialize, if we provide `options.config` without `options.compiler`, it will throw an error at https://github.com/shellscape/koa-webpack/blob/master/lib/index.js#L36, so we need to set `options.compiler`.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

None

### Additional Info

Update usage document