### PR TITLE
Fixing reference to config.devMiddleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ for more information and a workaround.
 
 ## Server-Side-Rendering
 
-When `serverSideRender` is set to true in `config.dev`, `webpackStats` is
+When `serverSideRender` is set to true in `config.devMiddleware`, `webpackStats` is
 accessible from `ctx.state.webpackStats`.
 
 ```js


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
This change makes the README clearer by referencing the actual config key `devMiddleware` instead of `dev` so that the user understands how to correctly configure the `serverSideRender` feature and understands that this is actually a `webpack-dev-middleware` feature and not just a `koa-webpack` feature.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info