### PR TITLE
feat: adding options.configPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,26 @@ const middleware = await koaWebpack({ config });
 app.use(middleware);
 ```
 
+### configPath
+
+Type: `String`
+
+Allows you to specify the absolute path to the Webpack config file to be used.
+
+Example:
+
+```js
+const path = require('path');
+const koaWebpack = require('koa-webpack');
+
+// The Webpack config file would be at "./client/webpack.config.js".
+const middleware = await koaWebpack({
+  configPath: path.join(__dirname, 'client', 'webpack.config.js')
+});
+
+app.use(middleware);
+```
+
 ### devMiddleware
 
 Type: `Object`

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ module.exports = async (opts) => {
   if (!compiler) {
     if (!config) {
       // eslint-disable-next-line import/no-dynamic-require, global-require
-      config = require(join(options.root || root.path, 'webpack.config.js'));
+      config = require(options.configPath || join(root.path, 'webpack.config.js'));
     }
 
     compiler = webpack(config);

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ module.exports = async (opts) => {
   if (!compiler) {
     if (!config) {
       // eslint-disable-next-line import/no-dynamic-require, global-require
-      config = require(join(root.path, 'webpack.config.js'));
+      config = require(join(options.root || root.path, 'webpack.config.js'));
     }
 
     compiler = webpack(config);

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -15,9 +15,9 @@ const { string, boolean, object, validate } = Joi.bind();
 module.exports = {
   validate(options) {
     const keys = {
-      root: [string().allow(null)],
       compiler: [object().allow(null)],
       config: [object().allow(null)],
+      configPath: [string().allow(null)],
       devMiddleware: [object()],
       hotClient: [boolean(), object().allow(null)]
     };

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -10,11 +10,12 @@
 */
 const Joi = require('@hapi/joi');
 
-const { boolean, object, validate } = Joi.bind();
+const { string, boolean, object, validate } = Joi.bind();
 
 module.exports = {
   validate(options) {
     const keys = {
+      root: [string().allow(null)],
       compiler: [object().allow(null)],
       config: [object().allow(null)],
       devMiddleware: [object()],

--- a/test/fixtures/webpack.config.js
+++ b/test/fixtures/webpack.config.js
@@ -1,0 +1,10 @@
+const { resolve } = require('path');
+
+module.exports = {
+  mode: 'development',
+  entry: [resolve(__dirname, 'input.js')],
+  output: {
+    path: __dirname,
+    filename: 'output.js'
+  }
+};


### PR DESCRIPTION
So that koa-webpack can be further upstream than one hop from
mainModule while still maintaining some sane default functionality.

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

If options.compiler or options.config is not specified, then koa-webpack defaults to {mainModule directory}/webpack.config.js which is usually a nice default but it doesn't work for me since I'm actually requiring koa-webpack from a module that is itself being required by the end-user application. 

As a workaround I was going to specify options.config manually but the validation logic in koa-webpack doesn't support Webpack multicompiler config since it would be an Array instead of an Object (even though it works when not manually specifying the config). I thought about submitting a PR to change the Joi validation, but couldn't get it to work and this solution seemed easier for the user.

I didn't make any doc changes, but I will if this feature will be accepted.