### PR TITLE
chore: modify require webpack-hot-client where 'hotClient' in options

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -8,13 +8,14 @@
   The above copyright notice and this permission notice shall be
   included in all copies or substantial portions of this Source Code Form.
 */
-const webpackHotClient = require('webpack-hot-client');
 
 module.exports = {
   getClient(compiler, options) {
     if (!options.hotClient) {
       return Promise.resolve(null);
     }
+
+    const webpackHotClient = require('webpack-hot-client');
 
     return new Promise((resolve) => {
       const client = webpackHotClient(compiler, options.hotClient);


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

Motivation / Use-Case

When there is no hotclient configuration, the webpack hot client is not introduced
